### PR TITLE
add stagecopy feature

### DIFF
--- a/ShadowSETIDEditor/Form1.Designer.cs
+++ b/ShadowSETIDEditor/Form1.Designer.cs
@@ -41,6 +41,10 @@
             this.comboBox1 = new System.Windows.Forms.ComboBox();
             this.label1 = new System.Windows.Forms.Label();
             this.checkedListBox1 = new System.Windows.Forms.CheckedListBox();
+            this.sourceLevelText = new System.Windows.Forms.TextBox();
+            this.targetLevelText = new System.Windows.Forms.TextBox();
+            this.cpyButton = new System.Windows.Forms.Button();
+            this.checkBoxCPYMode = new System.Windows.Forms.CheckBox();
             this.menuStrip1.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -51,7 +55,7 @@
             this.fileToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(396, 24);
+            this.menuStrip1.Size = new System.Drawing.Size(425, 24);
             this.menuStrip1.TabIndex = 0;
             this.menuStrip1.Text = "menuStrip1";
             // 
@@ -71,7 +75,7 @@
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.openToolStripMenuItem.Text = "Open";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
@@ -79,7 +83,7 @@
             // 
             this.saveToolStripMenuItem.Enabled = false;
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.saveToolStripMenuItem.Text = "Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
@@ -87,26 +91,26 @@
             // 
             this.saveAsToolStripMenuItem.Enabled = false;
             this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
-            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.saveAsToolStripMenuItem.Text = "Save As...";
             this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(177, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(120, 6);
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.exitToolStripMenuItem.Text = "Exit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
@@ -114,9 +118,9 @@
             // 
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripStatusLabel1});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 436);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 515);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(396, 22);
+            this.statusStrip1.Size = new System.Drawing.Size(425, 22);
             this.statusStrip1.TabIndex = 1;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -132,7 +136,7 @@
             this.comboBox1.FormattingEnabled = true;
             this.comboBox1.Location = new System.Drawing.Point(59, 27);
             this.comboBox1.Name = "comboBox1";
-            this.comboBox1.Size = new System.Drawing.Size(325, 21);
+            this.comboBox1.Size = new System.Drawing.Size(354, 21);
             this.comboBox1.TabIndex = 2;
             this.comboBox1.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged);
             // 
@@ -153,15 +157,55 @@
             this.checkedListBox1.FormattingEnabled = true;
             this.checkedListBox1.Location = new System.Drawing.Point(12, 54);
             this.checkedListBox1.Name = "checkedListBox1";
-            this.checkedListBox1.Size = new System.Drawing.Size(372, 379);
+            this.checkedListBox1.Size = new System.Drawing.Size(401, 454);
             this.checkedListBox1.TabIndex = 4;
             this.checkedListBox1.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.checkedListBox1_ItemCheck);
+            // 
+            // sourceLevelText
+            // 
+            this.sourceLevelText.Location = new System.Drawing.Point(60, 4);
+            this.sourceLevelText.Name = "sourceLevelText";
+            this.sourceLevelText.Size = new System.Drawing.Size(100, 20);
+            this.sourceLevelText.TabIndex = 5;
+            this.sourceLevelText.Text = "source";
+            // 
+            // targetLevelText
+            // 
+            this.targetLevelText.Location = new System.Drawing.Point(213, 4);
+            this.targetLevelText.Name = "targetLevelText";
+            this.targetLevelText.Size = new System.Drawing.Size(100, 20);
+            this.targetLevelText.TabIndex = 6;
+            this.targetLevelText.Text = "target";
+            // 
+            // cpyButton
+            // 
+            this.cpyButton.Location = new System.Drawing.Point(166, 3);
+            this.cpyButton.Name = "cpyButton";
+            this.cpyButton.Size = new System.Drawing.Size(41, 21);
+            this.cpyButton.TabIndex = 7;
+            this.cpyButton.Text = "CPY";
+            this.cpyButton.UseVisualStyleBackColor = true;
+            this.cpyButton.Click += new System.EventHandler(this.cpyButton_Click);
+            // 
+            // checkBoxCPYMode
+            // 
+            this.checkBoxCPYMode.AutoSize = true;
+            this.checkBoxCPYMode.Location = new System.Drawing.Point(319, 6);
+            this.checkBoxCPYMode.Name = "checkBoxCPYMode";
+            this.checkBoxCPYMode.Size = new System.Drawing.Size(96, 17);
+            this.checkBoxCPYMode.TabIndex = 8;
+            this.checkBoxCPYMode.Text = "CPY Only True";
+            this.checkBoxCPYMode.UseVisualStyleBackColor = true;
             // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(396, 458);
+            this.ClientSize = new System.Drawing.Size(425, 537);
+            this.Controls.Add(this.checkBoxCPYMode);
+            this.Controls.Add(this.cpyButton);
+            this.Controls.Add(this.targetLevelText);
+            this.Controls.Add(this.sourceLevelText);
             this.Controls.Add(this.checkedListBox1);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.comboBox1);
@@ -196,6 +240,10 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
+        private System.Windows.Forms.TextBox sourceLevelText;
+        private System.Windows.Forms.TextBox targetLevelText;
+        private System.Windows.Forms.Button cpyButton;
+        private System.Windows.Forms.CheckBox checkBoxCPYMode;
     }
 }
 

--- a/ShadowSETIDEditor/Form1.cs
+++ b/ShadowSETIDEditor/Form1.cs
@@ -121,6 +121,9 @@ namespace ShadowSETIDEditor
             }
         }
 
+        private bool srcFind = false;
+        private bool tgtFind = false;
+        private int srcPos, tgtPos;
         private bool programIsChangingStuff = false;
         private string currentFileName;
 
@@ -154,7 +157,7 @@ namespace ShadowSETIDEditor
 
         private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            MessageBox.Show("Shadow SET ID Table Editor release 1 by igorseabra4", "About", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            MessageBox.Show("Shadow SET ID Table Editor release 1 by igorseabra4\nStage CPY modification by dreamsyntax", "About", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
 
         private void exitToolStripMenuItem_Click(object sender, EventArgs e)
@@ -167,7 +170,7 @@ namespace ShadowSETIDEditor
             public ObjectEntry Object;
             public uint values0;
             public uint values1;
-            
+
             public override string ToString()
             {
                 return "[" + Object.list.ToString("X2") + "] [" + Object.type.ToString("X2") + "] " + Object.name;
@@ -177,7 +180,7 @@ namespace ShadowSETIDEditor
         private void LoadTable(string fileName)
         {
             currentFileName = fileName;
-            
+
             BinaryReader TableReader = new BinaryReader(new FileStream(currentFileName, FileMode.Open));
 
             comboBox1.Items.Clear();
@@ -251,7 +254,7 @@ namespace ShadowSETIDEditor
         private void comboBox1_SelectedIndexChanged(object sender, EventArgs e)
         {
             programIsChangingStuff = true;
-            
+
             for (int i = 0; i < checkedListBox1.Items.Count; i++)
             {
                 checkedListBox1.SetItemChecked(i,
@@ -277,6 +280,63 @@ namespace ShadowSETIDEditor
                     (comboBox1.SelectedItem as TableEntry).values1 = (comboBox1.SelectedItem as TableEntry).values1 ^ (checkedListBox1.Items[e.Index] as StageEntry).flag1;
                 }
             }
+        }
+
+        private void cpyButton_Click(object sender, EventArgs e)
+        {
+            //when sourceLevelText and endLevelText match to an existing stage, set them
+            string changes = "";
+            for (int i = 0; i < checkedListBox1.Items.Count; i++){
+                if(srcFind && tgtFind)
+                {
+                    MessageBox.Show("src:"+srcPos+"\ntgt:"+tgtPos, "About", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    changes = "Changes Done:";
+                    break;
+                }
+                if (sourceLevelText.Text == checkedListBox1.Items[i].ToString()){
+                    srcPos = i;
+                    srcFind = true;
+                }
+                if (targetLevelText.Text == checkedListBox1.Items[i].ToString()){
+                    tgtPos = i;
+                    tgtFind = true;
+                }
+            }
+            if (changes == "Changes Done:")
+            {
+                //begin copy source data to target data
+                for (int i = 0; i < comboBox1.Items.Count; i++)
+                {
+                    comboBox1.SelectedIndex = i;
+                    bool srcStatus = checkedListBox1.GetItemChecked(srcPos);
+                    bool tgtStatus = checkedListBox1.GetItemChecked(tgtPos);
+                    if (tgtStatus != srcStatus)
+                    {
+                        if (checkBoxCPYMode.Checked)
+                        {
+                            if (srcStatus)
+                            {
+                                //for CPYMode enabled, only copy when srcStatus is true, do not disable false
+                                changes = changes + "\nChanged: " + comboBox1.Items[i].ToString() + " from: " + tgtStatus + " to: " + srcStatus;
+                                checkedListBox1.SetItemChecked(tgtPos, srcStatus);
+                            }
+                        }
+                        else
+                        {
+                            //1:1 copy
+                            changes = changes + "\nChanged: " + comboBox1.Items[i].ToString() + " from: " + tgtStatus + " to: " + srcStatus;
+                            checkedListBox1.SetItemChecked(tgtPos, srcStatus);
+                        }
+                    }
+                }
+                MessageBox.Show(changes); //maybe output to file?
+            } else if (sourceLevelText.Text == "source" || targetLevelText.Text == "target"){
+                MessageBox.Show("Use CPY to copy all setid data from source stage and replace target stage's check/uncheck for all objects", "StageCopy Info", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBox.Show("Ensure stage name is typed exactly as shown in checkboxes!", "StageCopy Info", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            } else {
+                MessageBox.Show("Source or Target stage names were not found, Check spelling and try again!", "StageCopy Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+
         }
     }
 }


### PR DESCRIPTION
Visual changes:
- Button
- 2 TextBox
- CheckBox

Function:
Given stage A and stage B,
allow for copying true/false state of all objects in comboList for stage A to stage B.
Shows a MessageBox after operation listing changes. This could be changed to be another window or output file, but exists now only as a brief notice that the operation succeeded/failed. 

Ex. when CPY Only True is **NOT** checked (normal 1:1 copy)
For all objects within the comboList, set B's value to be the same true/false status as A. If B has a true value, but A has a false value, overwrite B's value with false.

Ex. when CPY Only True is checked (copy true values only)
For all objects within the comboList, set B's false value to be A's if and only if A is a true value. If B has a true value, but A has a false value, retain B's true value.

The non-checked mode (default) is the most useful for swapping stages, however there may be the case when certain hardcoded events in stages need some comboList object to be enabled in the stage to load properly, so for troubleshooting purposes it has been added.